### PR TITLE
GitHub Wiki自動同期機能の追加

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,51 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/wiki/**'
+  workflow_dispatch:
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Clone wiki repository
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki
+      
+      - name: Copy wiki files
+        run: |
+          # Remove old wiki files (except .git)
+          find wiki -type f -not -path "wiki/.git/*" -delete
+          
+          # Copy new wiki files
+          cp -r docs/wiki/* wiki/
+          
+          # Rename .md files to remove .md extension for GitHub Wiki
+          cd wiki
+          for file in *.md; do
+            if [ -f "$file" ]; then
+              mv "$file" "${file%.md}"
+            fi
+          done
+      
+      - name: Push to wiki
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Auto-sync from docs/wiki - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            git push origin master
+          fi


### PR DESCRIPTION
## 概要
docs/wiki/フォルダの変更を自動的にGitHub Wikiに同期するGitHub Actionsワークフローを追加しました。

## 変更内容
- `.github/workflows/sync-wiki.yml` を追加
- `docs/wiki/`フォルダの変更を検出して自動実行
- Markdownファイルを拡張子なしにリネームしてGitHub Wiki形式に変換
- 手動実行も可能

## テスト方法
- [ ] PRマージ後、`docs/wiki/`フォルダのファイルを編集してmasterブランチにpush
- [ ] GitHub Actionsが実行されることを確認
- [ ] GitHub Wikiに変更が反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)