### PR TITLE
GitHub Wiki同期の権限エラー修正

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -11,41 +11,17 @@ jobs:
   sync-wiki:
     runs-on: ubuntu-latest
     
+    permissions:
+      contents: write
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
-      - name: Clone wiki repository
-        run: |
-          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki
-      
-      - name: Copy wiki files
-        run: |
-          # Remove old wiki files (except .git)
-          find wiki -type f -not -path "wiki/.git/*" -delete
-          
-          # Copy new wiki files
-          cp -r docs/wiki/* wiki/
-          
-          # Rename .md files to remove .md extension for GitHub Wiki
-          cd wiki
-          for file in *.md; do
-            if [ -f "$file" ]; then
-              mv "$file" "${file%.md}"
-            fi
-          done
-      
-      - name: Push to wiki
-        run: |
-          cd wiki
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Auto-sync from docs/wiki - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-            git push origin master
-          fi
+      - name: Upload to Wiki
+        uses: SwiftDocOrg/github-wiki-publish-action@v1
+        with:
+          path: "docs/wiki"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
GitHub ActionsでWiki同期時に発生していた403権限エラーを修正しました。

## 問題
- `github-actions[bot]`にWikiリポジトリへの書き込み権限がなかった
- 手動のgit cloneとpushによる複雑な処理

## 解決策  
- `contents: write`権限を追加
- 専用アクション`SwiftDocOrg/github-wiki-publish-action@v1`を使用
- よりシンプルで確実な同期処理を実現

## テスト方法
- [ ] PRマージ後、`docs/wiki/`フォルダのファイルを編集
- [ ] masterブランチにpushしてActionsが正常実行されることを確認
- [ ] GitHub Wikiに変更が反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)