### PR TITLE
fix: Wiki同期アクションを変更

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Upload to Wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
+      - name: Sync to Wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
         with:
-          path: "docs/wiki"
+          path: docs/wiki/
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- SwiftDocOrgからAndrew-Chen-Wang/github-wiki-actionに変更
- GITHUB_TOKENで動作する確実なアクションを使用
- Personal Access Token不要

🤖 Generated with [Claude Code](https://claude.ai/code)