### PR TITLE
fix: Vercelビルドエラーを修正

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
-    "@shared/types": "*",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -21,14 +20,14 @@
     "react-dom": "^18",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.16",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8.57.1",
-    "eslint-config-next": "14.0.0",
-    "typescript": "^5"
+    "eslint-config-next": "14.0.0"
   }
 }

--- a/apps/frontend/src/components/TrendList.tsx
+++ b/apps/frontend/src/components/TrendList.tsx
@@ -3,7 +3,19 @@
 import { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { Badge } from './ui/badge'
-import { TrendsResponse } from '@shared/types'
+// 型定義
+interface Trend {
+  id: number
+  title: string
+  popularity: number
+  source?: string
+  tags?: string[]
+  url?: string
+}
+
+interface TrendsResponse {
+  trends: Trend[]
+}
 
 export default function TrendList() {
   const [trends, setTrends] = useState<TrendsResponse['trends']>([])


### PR DESCRIPTION
## 問題
Vercelデプロイ時に以下のエラーが発生していました：

```
⨯ ESLint must be installed in order to run during builds
It looks like you're trying to use TypeScript but do not have the required package(s) installed.
Please install typescript and @types/node by running:
    yarn add --dev typescript @types/node
Next.js build worker exited with code: 1
```

## 原因
1. **monorepo構造**: Vercelがworkspace依存関係を正しく解決できない
2. **TypeScript配置**: devDependenciesにあるとVercelビルド時に見つからない
3. **workspace参照**: `@shared/types`がVercel環境で解決できない

## 解決策

### 🛠️ vercel.json最適化
```json
{
  "version": 2,
  "functions": {
    "apps/backend/api/**/*.ts": {
      "runtime": "@vercel/node"
    }
  }
}
```
- buildCommand等を削除してVercelの自動検出に任せる
- Next.jsを`apps/frontend`のRoot Directoryで認識させる

### 📦 依存関係修正
- `typescript`を`dependencies`に移動（Vercelビルド時に必要）
- `@shared/types`依存を除去（monorepo問題回避）

### 🏷️ 型定義の直接配置
```typescript
// TrendList.tsx内に型定義を直接配置
interface Trend {
  id: number
  title: string
  popularity: number
  source?: string
  tags?: string[]
  url?: string
}
```

## テスト結果
- ✅ ローカルビルド成功
- ✅ TypeScript型チェック成功
- ✅ ESLintチェック成功

## Vercel設定
**Dashboard設定推奨:**
- Root Directory: `apps/frontend`
- Framework Preset: Next.js
- Build Command: `npm run build`
- Output Directory: `.next`

## 関連Issue
Resolves Vercelデプロイエラー

---
🤖 Generated with [Claude Code](https://claude.ai/code)