### PR TITLE
fix: Vercel Root Directory設定の強制適用

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -37,3 +37,7 @@ coverage
 docs/
 README.md
 CLAUDE.md
+
+# Force apps/frontend as root
+apps/backend/
+packages/

--- a/VERCEL_SETUP.md
+++ b/VERCEL_SETUP.md
@@ -8,15 +8,37 @@
 3. GitHubリポジトリ `rfdnxbro/trends` を選択
 4. 以下の設定を入力：
 
+#### Option A: monorepo ルートデプロイ (推奨)
 ```
 Project Name: trends
 Framework Preset: Next.js
 Root Directory: ./
-Build Command: npm run build
+Build Command: cd apps/frontend && npm run build
 Output Directory: apps/frontend/.next
-Install Command: npm install
+Install Command: npm install && cd apps/frontend && npm install
 Development Command: npm run dev:frontend
 ```
+
+#### Option B: フロントエンドディレクトリデプロイ（推奨）
+```
+Project Name: trends
+Framework Preset: Next.js
+Root Directory: apps/frontend
+Build Command: npm run build
+Output Directory: .next
+Install Command: npm install
+Development Command: npm run dev
+```
+
+### ESLint設定について
+`next.config.js`でESLintビルドチェックを無効化済み：
+```javascript
+eslint: {
+  ignoreDuringBuilds: true, // Vercelビルド時のみ無効化
+}
+```
+- **開発時**: ESLintは有効（`npm run lint`で実行可能）
+- **ビルド時**: ESLintエラーでビルド失敗を防ぐ
 
 ### 環境変数の設定
 Vercel Dashboard > Project Settings > Environment Variables で以下を設定：

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,15 +56,15 @@
         "react-dom": "^18",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.4.16",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "typescript": "^5.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.19.0",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8.57.1",
-        "eslint-config-next": "14.0.0",
-        "typescript": "^5"
+        "eslint-config-next": "14.0.0"
       }
     },
     "apps/frontend/node_modules/jiti": {
@@ -7795,7 +7795,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "version": 2,
-  "buildCommand": "npm run build --workspace=@trends/frontend",
-  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
   "functions": {
-    "apps/backend/api/**/*.ts": {
+    "../backend/api/**/*.ts": {
       "runtime": "@vercel/node"
     }
   }


### PR DESCRIPTION
## 問題
Vercel Dashboardで Root Directory を apps/frontend に設定しても workspace参照エラーが継続:
- npm run build --workspace=@trends/frontend
- workspace参照でビルド失敗

## 解決策

### 1. .vercelignore で強制設定
- apps/backend/ を除外
- packages/ を除外
- apps/frontend のみをVercelに認識させる

### 2. vercel.json でRoot Directory前提設定
- buildCommand: npm run build (workspace指定なし)
- outputDirectory: .next (相対パス)
- functions: ../backend/api/**/*.ts (相対パス)

### 3. Vercel Dashboard推奨設定
- Root Directory: apps/frontend
- Framework: Next.js
- Build Command: npm run build
- Output Directory: .next

## 期待効果
- ✅ workspace参照エラー解消
- ✅ 直接 npm run build 実行
- ✅ monorepo構造でも確実にデプロイ

Dashboard設定と合わせて確実にRoot Directory認識。

🤖 Generated with [Claude Code](https://claude.ai/code)