### PR TITLE
fix: Vercel workspace認識を完全に回避

### DIFF
--- a/.vercel
+++ b/.vercel
@@ -1,0 +1,1 @@
+apps/frontend

--- a/.vercelrc
+++ b/.vercelrc
@@ -1,0 +1,7 @@
+{
+  "public": false,
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "installCommand": "npm install"
+}

--- a/apps/frontend/.npmrc
+++ b/apps/frontend/.npmrc
@@ -1,0 +1,2 @@
+workspaces=false
+legacy-peer-deps=true


### PR DESCRIPTION
## 問題
Vercel Dashboard設定でRoot Directoryを指定してもworkspace参照エラーが継続：
```
npm error workspace @trends/frontend@0.1.0
```

## 解決策

### 追加設定ファイル

#### .vercel
```
apps/frontend
```
- Vercelプロジェクトのルートディレクトリを明示指定

#### .vercelrc
```json
{
  "framework": "nextjs",
  "buildCommand": "npm run build", 
  "outputDirectory": ".next",
  "installCommand": "npm install"
}
```

#### apps/frontend/.npmrc
```
workspaces=false
legacy-peer-deps=true
```
- フロントエンドディレクトリでworkspace機能を無効化

## 期待効果
- ✅ workspace参照エラーの完全解消
- ✅ `npm run build`の直接実行
- ✅ フロントエンドの独立動作

## 使用方法
1. 環境変数から不適切な設定を削除
2. Dashboard設定：Root Directory = apps/frontend
3. このPRをマージして再デプロイ

workspace問題を根本から解決します。

🤖 Generated with [Claude Code](https://claude.ai/code)