### PR TITLE
fix: Vercel Functionsランタイムバージョン修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "version": 2,
   "functions": {
-    "apps/backend/api/**/*.ts": {
-      "runtime": "@vercel/node"
+    "../backend/api/**/*.ts": {
+      "runtime": "@vercel/node@3.0.0"
     }
   }
 }


### PR DESCRIPTION
## 問題
Vercel Functionsランタイムバージョンエラー：
```
Error: Function Runtimes must have a valid version, for example `now-php@1.0.0`.
```

## 原因
`@vercel/node`にバージョン指定がなかった

## 解決策
### vercel.json修正
```json
{
  "functions": {
    "../backend/api/**/*.ts": {
      "runtime": "@vercel/node@3.0.0"  // ← バージョン追加
    }
  }
}
```

### 変更点
- ✅ ランタイムバージョン指定: `@vercel/node@3.0.0`
- ✅ Root Directory相対パス: `../backend/api/**/*.ts`

これでVercel Functionsが正常に動作します。

**すぐにマージして再デプロイしてください！**