### PR TITLE
fix: Vercel設定の根本的修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,6 @@
 {
   "version": 2,
-  "buildCommand": "npm run build:frontend",
+  "buildCommand": "npm run build",
   "outputDirectory": "apps/frontend/.next",
-  "installCommand": "npm install",
-  "functions": {
-    "apps/backend/api/[...route].ts": {
-      "runtime": "@vercel/node@3.0.0"
-    }
-  }
+  "installCommand": "npm install"
 }


### PR DESCRIPTION
## Summary
• Vercelデプロイエラーの根本原因を特定・修正
• buildCommandを`npm run build:frontend`→`npm run build`に変更
• functions設定を削除してVercelの自動検出機能を活用

## 問題の詳細
Vercelで以下のエラーが継続的に発生:
```
Error: The pattern "apps/backend/api/[...route].ts" defined in `functions` doesn't match any Serverless Functions.
```

## 根本原因
1. **buildCommand不備**: `npm run build:frontend`のみでバックエンドがビルドされていない
2. **functions設定競合**: 明示的パターン指定がVercelの自動検出と競合

## 解決策
1. **フルビルド実行**: `npm run build`でmonorepo全体をビルド
2. **自動検出委任**: functions設定削除により`/api`ディレクトリを自動認識

## Test plan
- [ ] Vercelデプロイが正常完了することを確認
- [ ] `/api/health`エンドポイントの正常応答を確認  
- [ ] `/api/trends`エンドポイントの正常応答を確認
- [ ] フロントエンドからのAPI呼び出しが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)