### PR TITLE
fix: バックエンドrootDir制約を削除

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES2022",
     "module": "commonjs",
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
• バックエンドのTypeScript rootDir制約エラーを修正
• API型チェックエラー `TS6059` を解決
• Vercel Functions用ファイルの正常な型処理を実現

## 問題詳細
```
error TS6059: File '/vercel/path1/apps/backend/api/[...route].ts' is not under 'rootDir' '/vercel/path1/apps/backend/src'. 'rootDir' is expected to contain all source files.
```

## 根本原因
- `tsconfig.json`の`rootDir`が`"./src"`に固定
- `api/[...route].ts`が`src/`の外にあるため型チェック対象外
- Vercel Functions用ファイルが処理されない

## 解決策
- **rootDir設定を削除**: TypeScriptの自動判定に委任
- **柔軟なルート検出**: `src/`と`api/`両フォルダを統合処理
- **include設定活用**: 既存の`["src/**/*", "api/**/*"]`が正常動作

## Test plan
- [ ] `npm run typecheck`でバックエンドエラーが解消されることを確認
- [ ] `api/[...route].ts`が型チェック対象に含まれることを確認
- [ ] Vercelデプロイが型エラーなしで完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)