### PR TITLE
fix: TypeScript types配列を削除

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],
-    "types": ["node"],
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
• TypeScript型定義エラー `TS2688` を修正
• types配列を削除して自動型検出を有効化
• Node.js型定義が正常に読み込まれるように修正

## 問題詳細
```
error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
```

## 根本原因
- `"types": ["node"]`の明示的指定がTypeScriptの型定義パス解決を阻害
- TypeScriptが自動的に`@types/node`を検出できない状態
- 明示的types配列は特定のファイルパスを要求するため失敗

## 解決策
- **types配列削除**: TypeScriptの自動型検出機能を活用
- **@types/node自動読み込み**: インストール済みパッケージが自動的に利用される
- **process等利用可能**: Node.js APIが型エラーなしで使用可能

## Test plan
- [ ] `npm run typecheck`でTS2688エラーが解消されることを確認
- [ ] `api/[...route].ts`内でprocess.envが正常に型チェックされることを確認
- [ ] Vercelデプロイが型エラーなしで完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)